### PR TITLE
Fix UI scaling

### DIFF
--- a/src/RdpNotifier/MainForm.Designer.cs
+++ b/src/RdpNotifier/MainForm.Designer.cs
@@ -95,8 +95,8 @@
             // 
             // MainForm
             // 
-            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
-            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             ClientSize = new System.Drawing.Size(482, 158);
             Controls.Add(textBox1);
             Controls.Add(checkBox1);

--- a/src/RdpNotifier/MainForm.Designer.cs
+++ b/src/RdpNotifier/MainForm.Designer.cs
@@ -87,7 +87,7 @@
             label2.Location = new System.Drawing.Point(30, 97);
             label2.Margin = new System.Windows.Forms.Padding(0);
             label2.Name = "label2";
-            label2.Size = new System.Drawing.Size(422, 41);
+            label2.Size = new System.Drawing.Size(422, 40);
             label2.TabIndex = 3;
             label2.Text = "✔ remote.contoso.com is online";
             label2.TextAlign = System.Drawing.ContentAlignment.BottomCenter;

--- a/src/RdpNotifier/MainForm.Designer.cs
+++ b/src/RdpNotifier/MainForm.Designer.cs
@@ -28,93 +28,89 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            this.textBox1 = new System.Windows.Forms.TextBox();
-            this.bindingSource1 = new System.Windows.Forms.BindingSource(this.components);
-            this.label1 = new System.Windows.Forms.Label();
-            this.checkBox1 = new System.Windows.Forms.CheckBox();
-            this.label2 = new System.Windows.Forms.Label();
-            ((System.ComponentModel.ISupportInitialize)(this.bindingSource1)).BeginInit();
-            this.SuspendLayout();
+            components = new System.ComponentModel.Container();
+            textBox1 = new System.Windows.Forms.TextBox();
+            bindingSource1 = new System.Windows.Forms.BindingSource(components);
+            label1 = new System.Windows.Forms.Label();
+            checkBox1 = new System.Windows.Forms.CheckBox();
+            label2 = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)bindingSource1).BeginInit();
+            SuspendLayout();
             // 
             // textBox1
             // 
-            this.textBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBox1.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.bindingSource1, "Address", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.textBox1.Font = new System.Drawing.Font("Segoe UI Semibold", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.textBox1.Location = new System.Drawing.Point(30, 40);
-            this.textBox1.Margin = new System.Windows.Forms.Padding(0);
-            this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(422, 32);
-            this.textBox1.TabIndex = 1;
+            textBox1.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            textBox1.DataBindings.Add(new System.Windows.Forms.Binding("Text", bindingSource1, "Address", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            textBox1.Font = new System.Drawing.Font("Segoe UI Semibold", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            textBox1.Location = new System.Drawing.Point(30, 40);
+            textBox1.Margin = new System.Windows.Forms.Padding(0);
+            textBox1.Name = "textBox1";
+            textBox1.Size = new System.Drawing.Size(422, 32);
+            textBox1.TabIndex = 1;
             // 
             // bindingSource1
             // 
-            this.bindingSource1.DataSource = typeof(RdpNotifier.MainViewModel);
+            bindingSource1.DataSource = typeof(MainViewModel);
             // 
             // label1
             // 
-            this.label1.AutoSize = true;
-            this.label1.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.label1.Location = new System.Drawing.Point(30, 20);
-            this.label1.Margin = new System.Windows.Forms.Padding(0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(65, 20);
-            this.label1.TabIndex = 0;
-            this.label1.Text = "Address:";
+            label1.AutoSize = true;
+            label1.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            label1.Location = new System.Drawing.Point(30, 20);
+            label1.Margin = new System.Windows.Forms.Padding(0);
+            label1.Name = "label1";
+            label1.Size = new System.Drawing.Size(65, 20);
+            label1.TabIndex = 0;
+            label1.Text = "Address:";
             // 
             // checkBox1
             // 
-            this.checkBox1.AutoSize = true;
-            this.checkBox1.Checked = true;
-            this.checkBox1.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBox1.DataBindings.Add(new System.Windows.Forms.Binding("Checked", this.bindingSource1, "PlaySound", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox1.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.checkBox1.Location = new System.Drawing.Point(30, 72);
-            this.checkBox1.Margin = new System.Windows.Forms.Padding(0);
-            this.checkBox1.Name = "checkBox1";
-            this.checkBox1.Size = new System.Drawing.Size(306, 25);
-            this.checkBox1.TabIndex = 2;
-            this.checkBox1.Text = "Play sound when connectivity is restored";
-            this.checkBox1.UseVisualStyleBackColor = true;
+            checkBox1.AutoSize = true;
+            checkBox1.Checked = true;
+            checkBox1.CheckState = System.Windows.Forms.CheckState.Checked;
+            checkBox1.DataBindings.Add(new System.Windows.Forms.Binding("Checked", bindingSource1, "PlaySound", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            checkBox1.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            checkBox1.Location = new System.Drawing.Point(30, 72);
+            checkBox1.Margin = new System.Windows.Forms.Padding(0);
+            checkBox1.Name = "checkBox1";
+            checkBox1.Size = new System.Drawing.Size(306, 25);
+            checkBox1.TabIndex = 2;
+            checkBox1.Text = "Play sound when connectivity is restored";
+            checkBox1.UseVisualStyleBackColor = true;
             // 
             // label2
             // 
-            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.label2.DataBindings.Add(new System.Windows.Forms.Binding("ForeColor", this.bindingSource1, "StatusColor", true, System.Windows.Forms.DataSourceUpdateMode.Never));
-            this.label2.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.bindingSource1, "Status", true, System.Windows.Forms.DataSourceUpdateMode.Never));
-            this.label2.Font = new System.Drawing.Font("Segoe UI Semilight", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.label2.Location = new System.Drawing.Point(30, 97);
-            this.label2.Margin = new System.Windows.Forms.Padding(0);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(422, 41);
-            this.label2.TabIndex = 3;
-            this.label2.Text = "✔ remote.contoso.com is online";
-            this.label2.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
-            this.label2.UseMnemonic = false;
+            label2.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            label2.DataBindings.Add(new System.Windows.Forms.Binding("ForeColor", bindingSource1, "StatusColor", true, System.Windows.Forms.DataSourceUpdateMode.Never));
+            label2.DataBindings.Add(new System.Windows.Forms.Binding("Text", bindingSource1, "Status", true, System.Windows.Forms.DataSourceUpdateMode.Never));
+            label2.Font = new System.Drawing.Font("Segoe UI Semilight", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            label2.Location = new System.Drawing.Point(30, 97);
+            label2.Margin = new System.Windows.Forms.Padding(0);
+            label2.Name = "label2";
+            label2.Size = new System.Drawing.Size(422, 41);
+            label2.TabIndex = 3;
+            label2.Text = "✔ remote.contoso.com is online";
+            label2.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
+            label2.UseMnemonic = false;
             // 
             // MainForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(482, 158);
-            this.Controls.Add(this.textBox1);
-            this.Controls.Add(this.checkBox1);
-            this.Controls.Add(this.label2);
-            this.Controls.Add(this.label1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.MaximizeBox = false;
-            this.Name = "MainForm";
-            this.Padding = new System.Windows.Forms.Padding(30, 20, 30, 20);
-            this.ShowIcon = false;
-            this.Text = "RDP Notifier";
-            ((System.ComponentModel.ISupportInitialize)(this.bindingSource1)).EndInit();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(482, 158);
+            Controls.Add(textBox1);
+            Controls.Add(checkBox1);
+            Controls.Add(label2);
+            Controls.Add(label1);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            MaximizeBox = false;
+            Name = "MainForm";
+            Padding = new System.Windows.Forms.Padding(30, 20, 30, 20);
+            ShowIcon = false;
+            Text = "RDP Notifier";
+            ((System.ComponentModel.ISupportInitialize)bindingSource1).EndInit();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion

--- a/src/RdpNotifier/MainForm.resx
+++ b/src/RdpNotifier/MainForm.resx
@@ -1,4 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">


### PR DESCRIPTION
The design was done on a monitor set at 125% DPI, and starting up on a monitor set at 100% is when the issue would happen.

Here's the current behavior:
![image](https://github.com/jnm2/RdpNotifier/assets/8040367/e98563f1-aa6d-4a6d-bb72-919d99e960b3)

After switching AutoScaleMode from Font to DPI, things act more reasonable, but the label still gets cut off when starting up on a monitor set to 100% DPI. 
Here's what it looks like when starting up on a monitor set to _125% DPI_ and then _moved_ to a 100% DPI monitor:
![image](https://github.com/jnm2/RdpNotifier/assets/8040367/6492ab92-369d-4bf0-8c63-9129f4db880b)

After shrinking the label by one pixel to work around <https://github.com/dotnet/winforms/issues/10490>, it now behaves properly when it starts up on a monitor set at 100% DPI, too:
![image](https://github.com/jnm2/RdpNotifier/assets/8040367/afb0a89a-6ef1-4c8b-81cb-026745a88adf)
